### PR TITLE
Potential fix for code scanning alert no. 1: Failure to use HTTPS or SFTP URL in Maven artifact upload/download

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <repositories>
         <repository>
             <id>nexus</id>
-            <url>http://192.168.1.15:8081/nexus/content/repositories/releases/</url>
+            <url>https://192.168.1.15:8081/nexus/content/repositories/releases/</url>
         </repository>
     </repositories>
     <distributionManagement>


### PR DESCRIPTION
Potential fix for [https://github.com/tcslabsfjbs/hello-java/security/code-scanning/1](https://github.com/tcslabsfjbs/hello-java/security/code-scanning/1)

To fix the problem, we need to change the repository URL from using the HTTP protocol to using the HTTPS protocol. This change should be made in the `repositories` section of the `pom.xml` file. Specifically, we need to update the URL on line 87 to use HTTPS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
